### PR TITLE
fix(db_dir): recursively create directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Fixed Issue #49
+
 ## [0.4.0] - 2021-01-19
 
 ### Changed
+
 * escape spaces in links with "%20". See https://github.com/rust-lang/mdBook/issues/527
 * remove IGNORE_TAG business, delete always deletes from hypothesis
 * list available groups on running `gooseberry config group` with the "use existing" option

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -146,7 +146,7 @@ file_extension = '{}'
     /// Make db and kb directories
     pub fn make_dirs(&self) -> color_eyre::Result<()> {
         if !self.db_dir.exists() {
-            fs::create_dir(&self.db_dir).map_err(|e: io::Error| Apologize::ConfigError {
+            fs::create_dir_all(&self.db_dir).map_err(|e: io::Error| Apologize::ConfigError {
                 message: format!(
                     "Couldn't create database directory {:?}, {}",
                     self.db_dir, e
@@ -155,7 +155,7 @@ file_extension = '{}'
         }
         if let Some(kb_dir) = &self.kb_dir {
             if !kb_dir.exists() {
-                fs::create_dir(&kb_dir).map_err(|e: io::Error| Apologize::ConfigError {
+                fs::create_dir_all(&kb_dir).map_err(|e: io::Error| Apologize::ConfigError {
                     message: format!(
                         "Couldn't create knowledge base directory {:?}, {}",
                         kb_dir, e


### PR DESCRIPTION
Closes #49

recursively creates `db_dir` and `kb_dir` to account for parent directories not existing.