### PR TITLE
feat(kb): add sort and page options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-* Fixed Issue #49
+### Fixed
+
+* Fixed Issue [#49](https://github.com/out-of-cheese-error/gooseberry/issues/49) - recursively creates db_dir and kb_dir
+
+### Added
+
+* Sort option `gooseberry config kb sort` (Issue [#48](https://github.com/out-of-cheese-error/gooseberry/issues/48))
+* Page template option `gooseberry config kb page` (Issue [#52](https://github.com/out-of-cheese-error/gooseberry/issues/52))
+
+### Changed
+
+* URI/BaseURI options don't have "http" and "https" in folder/file name anymore (these are also not used when sorting)
 
 ## [0.4.0] - 2021-01-19
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,28 @@ This uses #tags b/c Obsidian likes those.
 
 TODO add org-mode example
 
+#### Page template
+
+`gooseberry config kb page`
+
+Change the template used for rendering a single page (NOT the Index page).
+
+The following keys can be used inside the template:
+
+* `{{ name }}` - file stem
+* `{{ relative_path }}` - path relative to KB directory
+* `{{ absolute_path }}` - full path on filesystem
+* `annotations` - a list of *rendered* annotations (according to the annotation template)
+
+The default template is:
+
+```markdown
+# {{name}}
+
+{{#each annotations}}{{this}}{{/each}}
+
+```
+
 #### Grouping annotations into folders and pages
 
 `gooseberry config kb hierarchy`
@@ -246,7 +268,22 @@ annotations marked with that tag.
 
 `hierarchy = ["Tag"]` gives the structure in the `mdbook` figure above, i.e. no folders, a page for each tag.
 
-Annotations within a page are sorted by their date of creation (TODO: add `sort` configuration)
+#### Sorting annotations within a page
+
+`gooseberry config kb sort`
+
+This defines how annotations are sorted within each page.
+
+The available options are:
+
+* Tag - Sorts by tag (multiple tags are considered as "tag1,tag2,tag3" for sorting)
+* URI
+* BaseURI
+* ID
+* Created
+* Updated
+
+Multiple sort options can be combined in order of priority e.g. `sort = ["Tag", "Created"]` sorts by tags, then by the date of creation.
 
 #### Index link template
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -427,9 +427,18 @@ file_extension = '{}'
 
     pub(crate) fn get_templates(&self) -> Templates {
         Templates {
-            annotation_template: self.annotation_template.as_ref().unwrap(),
-            page_template: self.page_template.as_ref().unwrap(),
-            index_link_template: self.index_link_template.as_ref().unwrap(),
+            annotation_template: self
+                .annotation_template
+                .as_deref()
+                .unwrap_or(DEFAULT_ANNOTATION_TEMPLATE),
+            page_template: self
+                .page_template
+                .as_deref()
+                .unwrap_or(DEFAULT_PAGE_TEMPLATE),
+            index_link_template: self
+                .index_link_template
+                .as_deref()
+                .unwrap_or(DEFAULT_INDEX_LINK_TEMPLATE),
         }
     }
     /// Sets the annotation template in Handlebars format.

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -193,14 +193,18 @@ pub enum KbConfigCommand {
     Directory,
     /// Change annotation handlebars template
     Annotation,
+    /// Change page handlebars template
+    Page,
     /// Change index link handlebars template
     Link,
     /// Change index file name
     Index,
     /// Change knowledge base file extension
     Extension,
-    /// Change folder hierarchy
+    /// Change folder & file hierarchy
     Hierarchy,
+    /// Change sort order of annotations within a page
+    Sort,
 }
 
 impl ConfigCommand {
@@ -231,10 +235,12 @@ impl ConfigCommand {
                     KbConfigCommand::All => config.set_kb_all()?,
                     KbConfigCommand::Directory => config.set_kb_dir()?,
                     KbConfigCommand::Annotation => config.set_annotation_template()?,
+                    KbConfigCommand::Page => config.set_page_template()?,
                     KbConfigCommand::Link => config.set_index_link_template()?,
                     KbConfigCommand::Index => config.set_index_name()?,
                     KbConfigCommand::Extension => config.set_file_extension()?,
                     KbConfigCommand::Hierarchy => config.set_hierarchy()?,
+                    KbConfigCommand::Sort => config.set_sort()?,
                 };
             }
         }

--- a/src/gooseberry/mod.rs
+++ b/src/gooseberry/mod.rs
@@ -297,7 +297,10 @@ impl Gooseberry {
     }
 
     /// View optionally filtered annotations in the terminal
-    pub async fn view(&self, filters: Filters, id: Option<String>) -> color_eyre::Result<()> {
+    pub async fn view(&mut self, filters: Filters, id: Option<String>) -> color_eyre::Result<()> {
+        if self.config.annotation_template.is_none() {
+            self.config.set_annotation_template()?;
+        }
         let hbs = self.get_handlebars()?;
         if let Some(id) = id {
             let annotation = self

--- a/src/gooseberry/mod.rs
+++ b/src/gooseberry/mod.rs
@@ -8,7 +8,7 @@ use hypothesis::Hypothesis;
 use crate::configuration::GooseberryConfig;
 use crate::errors::Apologize;
 use crate::gooseberry::cli::{ConfigCommand, Filters, GooseberryCLI};
-use crate::gooseberry::knowledge_base::{get_handlebars, AnnotationTemplate};
+use crate::gooseberry::knowledge_base::AnnotationTemplate;
 
 /// Command-line interface with `structopt`
 pub mod cli;
@@ -74,11 +74,7 @@ impl Gooseberry {
             GooseberryCLI::Sync => self.sync().await,
             GooseberryCLI::Search { filters, fuzzy } => {
                 let annotations: Vec<Annotation> = self.filter_annotations(filters, None).await?;
-                let hbs = get_handlebars(
-                    self.config.annotation_template.as_ref().unwrap(),
-                    self.config.index_link_template.as_ref().unwrap(),
-                )?;
-                self.search(annotations, &hbs, fuzzy).await
+                self.search(annotations, fuzzy).await
             }
             GooseberryCLI::Tag {
                 filters,
@@ -141,7 +137,7 @@ impl Gooseberry {
 
     /// Move (optionally filtered) annotations from a different group to the group gooseberry looks at (set in config)
     pub async fn sync_group(
-        &self,
+        &mut self,
         group_id: String,
         filters: Filters,
         search: bool,
@@ -152,11 +148,7 @@ impl Gooseberry {
             .await?;
         if search || fuzzy {
             // Run a search window.
-            let hbs = get_handlebars(
-                self.config.annotation_template.as_ref().unwrap(),
-                self.config.index_link_template.as_ref().unwrap(),
-            )?;
-            let annotation_ids = Self::search_group(&annotations, &hbs, fuzzy)?;
+            let annotation_ids = self.search_group(&annotations, fuzzy)?;
             annotations = annotations
                 .into_iter()
                 .filter(|a| annotation_ids.contains(&a.id))
@@ -306,10 +298,7 @@ impl Gooseberry {
 
     /// View optionally filtered annotations in the terminal
     pub async fn view(&self, filters: Filters, id: Option<String>) -> color_eyre::Result<()> {
-        let hbs = get_handlebars(
-            self.config.annotation_template.as_ref().unwrap(),
-            self.config.index_link_template.as_ref().unwrap(),
-        )?;
+        let hbs = self.get_handlebars()?;
         if let Some(id) = id {
             let annotation = self
                 .api

--- a/src/gooseberry/search.rs
+++ b/src/gooseberry/search.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use dialoguer::console::style;
-use handlebars::Handlebars;
 use hypothesis::annotations::Annotation;
 use skim::prelude::{unbounded, Key, SkimOptionsBuilder};
 use skim::{
@@ -69,12 +68,12 @@ impl<'a> SkimItem for SearchAnnotation {
 impl Gooseberry {
     /// Makes a skim search window for given annotations
     pub async fn search(
-        &self,
+        &mut self,
         annotations: Vec<Annotation>,
-        hbs: &Handlebars<'_>,
         fuzzy: bool,
     ) -> color_eyre::Result<()> {
         let mut annotations = annotations;
+        let hbs = self.get_handlebars()?;
         let options = SkimOptionsBuilder::default()
             .height(Some("100%"))
             .preview(Some(""))
@@ -162,10 +161,11 @@ impl Gooseberry {
 
     /// Makes a skim search window for given annotations from an external group
     pub fn search_group(
+        &self,
         annotations: &[Annotation],
-        hbs: &Handlebars,
         fuzzy: bool,
     ) -> color_eyre::Result<HashSet<String>> {
+        let hbs = self.get_handlebars()?;
         let options = SkimOptionsBuilder::default()
             .height(Some("100%"))
             .preview(Some(""))

--- a/src/gooseberry/search.rs
+++ b/src/gooseberry/search.rs
@@ -73,6 +73,9 @@ impl Gooseberry {
         fuzzy: bool,
     ) -> color_eyre::Result<()> {
         let mut annotations = annotations;
+        if self.config.annotation_template.is_none() {
+            self.config.set_annotation_template()?;
+        }
         let hbs = self.get_handlebars()?;
         let options = SkimOptionsBuilder::default()
             .height(Some("100%"))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use chrono_english::{parse_date_string, Dialect};
 use color_eyre::Section;
 use dialoguer::{theme, Editor, Input};
 use hypothesis::annotations::Selector;
+use url::Url;
 
 use crate::errors::Apologize;
 
@@ -106,9 +107,25 @@ pub fn get_quotes(annotation: &hypothesis::annotations::Annotation) -> Vec<&str>
         .collect::<Vec<_>>()
 }
 
+pub fn clean_uri(uri: &str) -> String {
+    match Url::parse(uri) {
+        Ok(parsed_uri) => {
+            if parsed_uri.scheme() == "urn" {
+                uri.to_owned()
+            } else {
+                parsed_uri[url::Position::AfterScheme..url::Position::BeforePath]
+                    .trim_start_matches("://")
+                    .to_owned()
+            }
+        }
+        Err(_) => uri.to_owned(),
+    }
+}
+
 /// Converts a URI into something that can be used as a folder/filename
 pub fn uri_to_filename(uri: &str) -> String {
-    uri.replace("://", "_")
+    clean_uri(uri)
+        .replace("://", "_")
         .replace(".", "_")
         .replace("/", "_")
         .replace(":", "_")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -31,7 +31,9 @@ hypothesis_key = '{}'
 hypothesis_group = '{}'
 kb_dir = '{}'
 hierarchy = ['Tag']
+sort = ['Created']
 annotation_template = '''{}'''
+page_template = '''{}'''
 index_link_template = '''{}'''
 index_name = '{}'
 file_extension = '{}'"#,
@@ -41,6 +43,7 @@ file_extension = '{}'"#,
         group_id,
         kb_dir.to_str().unwrap(),
         gooseberry::configuration::DEFAULT_ANNOTATION_TEMPLATE,
+        gooseberry::configuration::DEFAULT_PAGE_TEMPLATE,
         gooseberry::configuration::DEFAULT_INDEX_LINK_TEMPLATE,
         gooseberry::configuration::DEFAULT_INDEX_FILENAME,
         gooseberry::configuration::DEFAULT_FILE_EXTENSION


### PR DESCRIPTION
* Sort option (gooseberry config kb sort)
* Page template option
(gooseberry config kb page)
* URI/BaseURI options don't have "http" and
"https" in folder/file name anymore (these are also not used when
sorting)

Closes #48, closes #52