### PR TITLE
feat(cli): allow config file as argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Use DEFAULT_PAGE_TEMPLATE in editor
 * Remove trailing "/" from URLs before converting them into filenames (Issue [#57](https://github.com/out-of-cheese-error/gooseberry/issues/57))
 
+### Added
+
+* Use --config or -c to open gooseberry with a specific config file. If empty, takes from GOOSEBERRY_CONFIG environment variable or uses default
+  location (Issue [#54](https://github.com/out-of-cheese-error/gooseberry/issues/54))
+
 ## [0.5.1] - 2020-01-21
 
 ### Fixed

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -7,7 +7,7 @@ use color_eyre::Help;
 use dialoguer::{theme, Confirm, Select};
 use directories_next::{ProjectDirs, UserDirs};
 use hypothesis::annotations::{Annotation, Permissions, Selector, Target, UserInfo};
-use hypothesis::Hypothesis;
+use hypothesis::{Hypothesis, UserAccountID};
 use serde::{Deserialize, Serialize};
 
 use crate::errors::Apologize;
@@ -157,8 +157,8 @@ file_extension = '{}'
     }
 
     /// Print location of config.toml file
-    pub fn print_location() -> color_eyre::Result<()> {
-        println!("{}", Self::location()?.to_string_lossy());
+    pub fn print_location(config_file: Option<String>) -> color_eyre::Result<()> {
+        println!("{}", Self::location(config_file)?.to_string_lossy());
         Ok(())
     }
 
@@ -194,8 +194,7 @@ file_extension = '{}'
     }
 
     /// Gets the current config file location
-    pub fn location() -> color_eyre::Result<PathBuf> {
-        let config_file = env::var("GOOSEBERRY_CONFIG").ok();
+    pub fn location(config_file: Option<String>) -> color_eyre::Result<PathBuf> {
         match config_file {
             Some(file) => {
                 let path = Path::new(&file).to_owned();
@@ -218,8 +217,8 @@ file_extension = '{}'
 
     /// Get current configuration
     /// Hides the developer key (except last three digits)
-    pub fn get() -> color_eyre::Result<String> {
-        let mut file = fs::File::open(Self::location()?)?;
+    pub fn get(config_file: Option<String>) -> color_eyre::Result<String> {
+        let mut file = fs::File::open(Self::location(config_file)?)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
         Ok(contents
@@ -243,9 +242,8 @@ file_extension = '{}'
     }
 
     /// Read config from default location
-    pub async fn load() -> color_eyre::Result<Self> {
+    pub async fn load(config_file: Option<String>) -> color_eyre::Result<Self> {
         // Reads the GOOSEBERRY_CONFIG environment variable to get config file location
-        let config_file = env::var("GOOSEBERRY_CONFIG").ok();
         let mut config = match config_file {
             Some(file) => {
                 let path = Path::new(&file).to_owned();
@@ -760,7 +758,7 @@ file_extension = '{}'
             .fetch_user_profile()
             .await?
             .userid
-            .is_some())
+            == Some(UserAccountID(format!("acct:{}@hypothes.is", name))))
     }
 
     /// Asks user for Hypothesis credentials and sets them in the config

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use hypothesis::annotations::{Order, SearchQuery, Sort};
@@ -21,8 +21,8 @@ global_settings = & [AppSettings::DeriveDisplayOrder, AppSettings::ColoredHelp]
 /// Create and manage your Hypothesis knowledge-base
 pub struct GooseberryCLI {
     /// Location of config file (uses default XDG location or environment variable if not given)
-    #[structopt(short, long, env = "GOOSEBERRY_CONFIG")]
-    pub(crate) config: Option<String>,
+    #[structopt(short, long, parse(from_os_str), env = "GOOSEBERRY_CONFIG")]
+    pub(crate) config: Option<PathBuf>,
     #[structopt(subcommand)]
     pub(crate) cmd: GooseberrySubcommand,
 }
@@ -218,13 +218,13 @@ pub enum KbConfigCommand {
 
 impl ConfigCommand {
     /// Handle config related commands
-    pub async fn run(&self, config_file: Option<String>) -> color_eyre::Result<()> {
+    pub async fn run(&self, config_file: Option<&Path>) -> color_eyre::Result<()> {
         match self {
             Self::Default { file } => {
                 GooseberryConfig::default_config(file.as_deref())?;
             }
             Self::Get => {
-                GooseberryConfig::load(config_file.clone()).await?;
+                GooseberryConfig::load(config_file).await?;
                 println!("{}", GooseberryConfig::get(config_file)?);
             }
             Self::Where => {

--- a/src/gooseberry/mod.rs
+++ b/src/gooseberry/mod.rs
@@ -37,14 +37,14 @@ impl Gooseberry {
     /// (makes new ones the first time).
     pub async fn start(cli: GooseberryCLI) -> color_eyre::Result<()> {
         if let GooseberrySubcommand::Config { cmd } = &cli.cmd {
-            return Ok(ConfigCommand::run(cmd, cli.config.clone()).await?);
+            return Ok(ConfigCommand::run(cmd, cli.config.as_deref()).await?);
         }
         if let GooseberrySubcommand::Complete { shell } = &cli.cmd {
             GooseberryCLI::complete(*shell);
             return Ok(());
         }
         // Reads the GOOSEBERRY_CONFIG environment variable to get config file location
-        let config = GooseberryConfig::load(cli.config.clone()).await?;
+        let config = GooseberryConfig::load(cli.config.as_deref()).await?;
         let api = Hypothesis::new(
             config
                 .hypothesis_username

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -62,7 +62,8 @@ fn it_works() -> color_eyre::Result<()> {
     let group_id = dotenv::var("TEST_GROUP_ID")?;
     let config_file = make_config_file(&temp_dir, &username, &key, &group_id)?;
     let mut cmd = Command::cargo_bin("gooseberry")?;
-    cmd.env("GOOSEBERRY_CONFIG", config_file)
+    cmd.arg("-c")
+        .arg(config_file)
         .arg("view")
         .assert()
         .success();


### PR DESCRIPTION
Use -c or --config to use a specific config file when running gooseberry

Closes #54
