### PR TITLE
Feat/tag manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * `ignore_tags` config option (Issue [#60](https://github.com/out-of-cheese-error/gooseberry/issues/60))
+* Tag manager that displays a search window of existing tags to add/remove and allows creating new tags (
+  Issue [#63](https://github.com/out-of-cheese-error/gooseberry/issues/63))
+* Add/remove multiple tags at once using comma-separated input e.g `gooseberry tag --from=today tag1,tag2,tag3`
 
 ## [0.5.2] - 2020-01-21
 

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -46,8 +46,9 @@ pub enum GooseberrySubcommand {
         /// Use this flag to remove the given tag from the filtered annotations instead of adding it
         #[structopt(short, long)]
         delete: bool,
-        /// The tag to add to / remove from the filtered annotations
-        tag: Option<String>,
+        /// The tags to add to / remove from the filtered annotations (comma-separated)
+        #[structopt(use_delimiter = true)]
+        tag: Vec<String>,
     },
     /// Delete annotations in bulk
     Delete {


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Added a search window for selecting from existing tags. New ones are created from unfound search queries. When adding tags, only tags not already present in filtered annotations are shown and creation is allowed. When removing tags, only tags present in filtered annotations are shown and creation is not allowed.

This PR also adds support for entering multiple comma-separated tags as input to `gooseberry tag` and in the search query to create new tags.

Closes #63 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/out-of-cheese-error/gooseberry/blob/master/docs/CONTRIBUTING.md
- you have linted the code using clippy:
  https://github.com/rust-lang/rust-clippy
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all` (see CONTRIBUTING.md for information on setting up tests)
- you have updated the changelog (if needed):
  https://github.com/out-of-cheese-error/gooseberry/blob/master/CHANGELOG.md
-->
