### PR TITLE
Store annotations locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ## Changed
-Store annotations in local database for faster search and retrieval. (Issue [#76](https://github.com/out-of-cheese-error/gooseberry/issues/76))
+- Store annotations in local database for faster search and retrieval. (Issue [#76](https://github.com/out-of-cheese-error/gooseberry/issues/76))
+- Use --and to match ALL tags, default matches ANY tag (previously --or)
+
+## Fixed
+- Help strings in CLI
 
 ## [0.9.3] - 2022-04-30
 ### Changed
@@ -177,6 +181,8 @@ Main commands:
   location of the knowledge base
 * `gooseberry move` - move annotations from one group to another (**move** not copy). Useful if you have a bunch of
   annotations scattered around and want to move them into one group for gooseberry.
+
+[0.9.3]: https://github.com/out-of-cheese-error/gooseberry/compare/0.9.2...0.9.3
 
 [0.9.2]: https://github.com/out-of-cheese-error/gooseberry/compare/0.9.1...0.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Changed
+Store annotations in local database for faster search and retrieval. (Issue [#76](https://github.com/out-of-cheese-error/gooseberry/issues/76))
+
 ## [0.9.3] - 2022-04-30
 ### Changed
 - Updated rust-hypothesis to 0.10.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1148,9 +1175,9 @@ version = "0.9.3"
 dependencies = [
  "assert_cmd",
  "bat",
- "bincode",
  "chrono",
  "chrono-english",
+ "ciborium",
  "color-eyre",
  "confy",
  "dialoguer",
@@ -1194,6 +1221,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "handlebars"
@@ -2007,7 +2040,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.6",
  "redox_syscall 0.2.13",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bat"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59cdca60e52d7c8ea28dd2b627ab0478e4d4a2df7cc30a13322aadb21035217"
+checksum = "fd1212d80800b3d7614b3725e0b2ee3b45b2b7484805d54b5660c8fa6f706305"
 dependencies = [
  "ansi_colours",
  "ansi_term 0.12.1",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
+checksum = "d8c8ae48e400addc32a8710c8d62d55cb84249a7d58ac4cd959daecfbaddc545"
 dependencies = [
  "console",
  "tempfile",
@@ -1497,25 +1497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
-
-[[package]]
-name = "line-wrap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -1886,20 +1871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
-name = "plist"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679104537029ed2287c216bfb942bbf723f48ee98f0aef15611634173a74ef21"
-dependencies = [
- "base64",
- "chrono",
- "indexmap",
- "line-wrap",
- "serde",
- "xml-rs",
-]
-
-[[package]]
 name = "predicates"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,12 +2167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "sanitize-filename"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf18934a12018228c5b55a6dae9df5d0641e3566b3630cb46cc55564068e7c2f"
+checksum = "08c502bdb638f1396509467cb0580ef3b29aa2a45c5d43e5d84928241280296c"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2298,18 +2263,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2318,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2576,20 +2541,22 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
 dependencies = [
+ "bincode",
  "bitflags",
  "fancy-regex",
+ "flate2",
  "fnv",
  "lazy_static",
- "lazycell",
- "plist",
+ "once_cell",
  "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "walkdir",
 ]
 
@@ -2647,18 +2614,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2749,9 +2716,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.0"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f48b6d60512a392e34dbf7fd456249fd2de3c83669ab642e021903f4015185b"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",
@@ -3208,12 +3175,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0.30"
 serde = "1.0.136"
 serde_json = "1.0.79"
 serde_derive = "1.0.136"
-bincode = "1.3.3"
+ciborium = "0.2.0"
 
 # Parsing and manipulating dates
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "README.md"]
 [dependencies]
 # Hypothesis
 hypothesis = { version = "0.10.3", default-features = false }
-tokio = { version = "1.18.0", features = ["macros"] }
+tokio = { version = "1.18.2", features = ["macros"] }
 
 # To extract the base URI
 url = "2.2.2"
@@ -32,12 +32,12 @@ directories-next = "1.0.1"
 # Error handling
 eyre = "0.6.8"
 color-eyre = "0.6.1"
-thiserror = "1.0.30"
+thiserror = "1.0.31"
 
 # Serializing
-serde = "1.0.136"
-serde_json = "1.0.79"
-serde_derive = "1.0.136"
+serde = "1.0.137"
+serde_json = "1.0.81"
+serde_derive = "1.0.137"
 ciborium = "0.2.0"
 
 # Parsing and manipulating dates
@@ -48,8 +48,8 @@ chrono-english = "0.1.7"
 skim = "0.9.4"
 
 # Console related
-dialoguer = "0.10.0"
-bat = { version = "0.20.0", default-features = false, features = ["regex-fancy"] }
+dialoguer = "0.10.1"
+bat = { version = "0.21.0", default-features = false, features = ["regex-fancy"] }
 
 # Indicator bar
 indicatif = "0.16.2"
@@ -58,7 +58,7 @@ indicatif = "0.16.2"
 handlebars = "4.2.2"
 
 # Sanitizing filenames
-sanitize-filename = "0.3.0"
+sanitize-filename = "0.4.0"
 handlebars_misc_helpers = "0.12.1"
 
 [dev-dependencies]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -36,7 +36,8 @@ pub static DEFAULT_PAGE_TEMPLATE: &str = r#"
 {{#each annotations}}{{this}}{{/each}}
 
 "#;
-pub static DEFAULT_INDEX_LINK_TEMPLATE: &str = r#"- [{{name}}]({{relative_path}})"#;
+pub static DEFAULT_INDEX_LINK_TEMPLATE: &str = r#"
+- [{{name}}]({{relative_path}})"#;
 pub static DEFAULT_INDEX_FILENAME: &str = "SUMMARY";
 pub static DEFAULT_FILE_EXTENSION: &str = "md";
 

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -154,7 +154,7 @@ pub struct Filters {
     /// Only annotations with this pattern in their `quote`, `tags`, `text`, or `uri`
     #[structopt(default_value, long)]
     pub any: String,
-    /// Only annotations with ALL of these tags (use --or to match ANY)
+    /// Only annotations with ANY of these tags (use --and to match ALL)
     #[structopt(long, use_delimiter = true, multiple = true)]
     pub tags: Vec<String>,
     /// Only annotations without ANY of these tags
@@ -169,9 +169,9 @@ pub struct Filters {
     /// Annotations NOT matching the given filter criteria
     #[structopt(short, long)]
     pub not: bool,
-    /// (Use with --tags) Annotations matching ANY of the given tags
-    #[structopt(short, long, requires = "tags")]
-    pub or: bool,
+    /// (Use with --tags) Annotations matching ALL of the given tags
+    #[structopt(long, requires = "tags")]
+    pub and: bool,
     /// Only page notes
     #[structopt(short, long)]
     pub page: bool,

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -130,7 +130,6 @@ pub enum GooseberrySubcommand {
     },
 }
 
-/// CLI options for filtering annotations
 #[derive(StructOpt, Debug, Default, Clone)]
 pub struct Filters {
     /// Only annotations created after this date and time

--- a/src/gooseberry/database.rs
+++ b/src/gooseberry/database.rs
@@ -67,15 +67,30 @@ impl Gooseberry {
         Ok(self.db.open_tree("tag_to_annotations")?)
     }
 
+    /// Tree storing annotation ID: annotation
+    /// Referred to as the tags tree
+    pub fn annotations(&self) -> color_eyre::Result<sled::Tree> {
+        Ok(self.db.open_tree("annotations")?)
+    }
+
     pub fn add_to_tag(&self, tag_key: &[u8], annotation_key: &[u8]) -> color_eyre::Result<()> {
         self.tag_to_annotations()?.merge(tag_key, annotation_key)?;
         Ok(())
     }
 
-    /// Add an annotation to both trees
+    /// Add an annotation to the annotations tree
+    pub fn add_to_annotations(&self, annotation: Annotation) -> color_eyre::Result<()> {
+        let mut annotation_bytes = Vec::new();
+        ciborium::ser::into_writer(&annotation, &mut annotation_bytes)?;
+        self.annotations()?
+            .insert(annotation.id.as_bytes(), &*annotation_bytes)?;
+        Ok(())
+    }
+
+    /// Add an annotation to all trees
     pub fn add_annotation(
         &self,
-        annotation: &Annotation,
+        annotation: Annotation,
         annotation_batch: &mut sled::Batch,
     ) -> color_eyre::Result<()> {
         let annotation_key = annotation.id.as_bytes();
@@ -91,13 +106,14 @@ impl Gooseberry {
                 self.add_to_tag(tag_key, annotation_key)?;
             }
         }
+        self.add_to_annotations(annotation)?;
         Ok(())
     }
 
     /// add or update annotations from the Hypothesis API
     pub fn sync_annotations(
         &self,
-        annotations: &[Annotation],
+        annotations: Vec<Annotation>,
     ) -> color_eyre::Result<(usize, usize)> {
         let (mut added, mut updated) = (0, 0);
         let mut annotation_batch = sled::Batch::default();
@@ -117,7 +133,11 @@ impl Gooseberry {
     }
 
     /// Delete an annotation index from the tag tree
-    pub fn delete_from_tag(&self, tag_key: &[u8], annotation_id: &str) -> color_eyre::Result<()> {
+    pub fn delete_from_tag_to_annotations_tree(
+        &self,
+        tag_key: &[u8],
+        annotation_id: &str,
+    ) -> color_eyre::Result<()> {
         let new_indices: Vec<_> =
             utils::split_ids(&self.tag_to_annotations()?.get(tag_key)?.ok_or(
                 Apologize::TagNotFound {
@@ -136,8 +156,8 @@ impl Gooseberry {
         Ok(())
     }
 
-    /// Delete an annotation ID from the annotation tree
-    pub fn delete_from_annotations(&self, id: &str) -> color_eyre::Result<Vec<String>> {
+    /// Delete an annotation ID from the annotation to tags tree
+    pub fn delete_from_annotation_to_tags_tree(&self, id: &str) -> color_eyre::Result<Vec<String>> {
         let annotation_key = id.as_bytes();
         utils::split_ids(
             &self
@@ -147,31 +167,42 @@ impl Gooseberry {
         )
     }
 
+    pub fn delete_from_annotations_tree(&self, id: &str) -> color_eyre::Result<()> {
+        let annotation_key = id.as_bytes();
+        self.annotations()?.remove(annotation_key)?;
+        Ok(())
+    }
+
     /// Delete annotation from database
     pub fn delete_annotation(&self, id: &str) -> color_eyre::Result<Vec<String>> {
-        let tags = self.delete_from_annotations(id)?;
+        let tags = self.delete_from_annotation_to_tags_tree(id)?;
         for tag in &tags {
             if tag.is_empty() {
                 continue;
             }
-            self.delete_from_tag(tag.as_bytes(), id)?;
+            self.delete_from_tag_to_annotations_tree(tag.as_bytes(), id)?;
         }
+        self.delete_from_annotations_tree(id)?;
         Ok(tags)
     }
 
     /// Delete multiple annotations
     pub fn delete_annotations(&self, ids: &[String]) -> color_eyre::Result<Vec<Vec<String>>> {
-        let mut annotation_batch = sled::Batch::default();
+        let mut annotation_to_tags_batch = sled::Batch::default();
         let mut tags_list = Vec::with_capacity(ids.len());
+        let mut annotation_batch = sled::Batch::default();
         for id in ids {
             let tags = self.get_annotation_tags(id)?;
+            annotation_to_tags_batch.remove(id.as_bytes());
             annotation_batch.remove(id.as_bytes());
             for tag in &tags {
-                self.delete_from_tag(tag.as_bytes(), id)?;
+                self.delete_from_tag_to_annotations_tree(tag.as_bytes(), id)?;
             }
             tags_list.push(tags);
         }
-        self.annotation_to_tags()?.apply_batch(annotation_batch)?;
+        self.annotation_to_tags()?
+            .apply_batch(annotation_to_tags_batch)?;
+        self.annotations()?.apply_batch(annotation_batch)?;
         Ok(tags_list)
     }
 
@@ -198,5 +229,26 @@ impl Gooseberry {
         } else {
             Ok(tags)
         }
+    }
+
+    /// Retrieve annotation by ID
+    pub fn get_annotation(&self, id: &str) -> color_eyre::Result<Annotation> {
+        let annotation_key = id.as_bytes();
+        let annotation_bytes = self
+            .annotations()?
+            .get(annotation_key)?
+            .ok_or(Apologize::AnnotationNotFound { id: id.to_owned() })?;
+        let annotation: Annotation = ciborium::de::from_reader(&*annotation_bytes)?;
+        Ok(annotation)
+    }
+
+    pub fn iter_annotations(
+        &self,
+    ) -> color_eyre::Result<impl Iterator<Item = color_eyre::Result<Annotation>>> {
+        Ok(self.annotations()?.iter().map(|item| {
+            let (_k, v) = item?;
+            let annotation: Annotation = ciborium::de::from_reader(&*v)?;
+            Ok(annotation)
+        }))
     }
 }

--- a/src/gooseberry/knowledge_base.rs
+++ b/src/gooseberry/knowledge_base.rs
@@ -271,7 +271,7 @@ impl Gooseberry {
     }
 
     /// Make mdBook wiki
-    pub async fn make(
+    pub fn make(
         &mut self,
         annotations: Vec<Annotation>,
         clear: bool,
@@ -296,11 +296,11 @@ impl Gooseberry {
             fs::remove_dir_all(&kb_dir)?;
             fs::create_dir_all(&kb_dir)?;
         }
-        self.make_book(annotations, kb_dir, make, index).await?;
+        self.make_book(annotations, kb_dir, make, index)?;
         Ok(())
     }
     /// Write markdown files for wiki
-    async fn make_book(
+    fn make_book(
         &self,
         annotations: Vec<Annotation>,
         src_dir: &Path,

--- a/src/gooseberry/mod.rs
+++ b/src/gooseberry/mod.rs
@@ -77,7 +77,7 @@ impl Gooseberry {
         match cli.cmd {
             GooseberrySubcommand::Sync => self.sync().await,
             GooseberrySubcommand::Search { filters, fuzzy } => {
-                let annotations: Vec<Annotation> = self.filter_annotations(filters, None).await?;
+                let annotations: Vec<Annotation> = self.filter_annotations(filters)?;
                 self.search(annotations, fuzzy).await
             }
             GooseberrySubcommand::Tag {
@@ -85,15 +85,15 @@ impl Gooseberry {
                 delete,
                 tag,
             } => {
-                let annotations: Vec<Annotation> = self.filter_annotations(filters, None).await?;
+                let annotations: Vec<Annotation> = self.filter_annotations(filters)?;
                 let tags = if tag.is_empty() { None } else { Some(tag) };
                 self.tag(annotations, delete, tags).await
             }
             GooseberrySubcommand::Delete { filters, force } => {
-                let annotations = self.filter_annotations(filters, None).await?;
+                let annotations = self.filter_annotations(filters)?;
                 self.delete(annotations, force).await
             }
-            GooseberrySubcommand::View { filters, id } => self.view(filters, id).await,
+            GooseberrySubcommand::View { filters, id } => self.view(filters, id),
             GooseberrySubcommand::Move {
                 group_id,
                 filters,
@@ -105,29 +105,23 @@ impl Gooseberry {
                 clear,
                 force,
                 no_index,
-            } => {
-                self.make(
-                    self.filter_annotations_make(filters).await?,
-                    clear,
-                    force,
-                    true,
-                    !no_index,
-                )
-                .await
-            }
-            GooseberrySubcommand::Index { filters } => {
-                self.make(
-                    self.filter_annotations_make(filters).await?,
-                    false,
-                    false,
-                    false,
-                    true,
-                )
-                .await
-            }
+            } => self.make(
+                self.filter_annotations_make(filters)?,
+                clear,
+                force,
+                true,
+                !no_index,
+            ),
+            GooseberrySubcommand::Index { filters } => self.make(
+                self.filter_annotations_make(filters)?,
+                false,
+                false,
+                false,
+                true,
+            ),
             GooseberrySubcommand::Clear { force } => self.clear(force),
             GooseberrySubcommand::Uri { filters, ids } => {
-                let annotations: Vec<Annotation> = self.filter_annotations(filters, None).await?;
+                let annotations: Vec<Annotation> = self.filter_annotations(filters)?;
                 self.uri(annotations, ids)
             }
             _ => Ok(()), // Already handled
@@ -154,7 +148,7 @@ impl Gooseberry {
             )
             .build()?;
         let (added, updated) =
-            self.sync_annotations(&self.api.search_annotations_return_all(&mut query).await?)?;
+            self.sync_annotations(self.api.search_annotations_return_all(&mut query).await?)?;
         self.set_sync_time(&query.search_after)?;
         spinner.finish_with_message("Done!");
         if added > 0 {
@@ -186,7 +180,7 @@ impl Gooseberry {
         fuzzy: bool,
     ) -> color_eyre::Result<()> {
         let mut annotations = self
-            .filter_annotations(filters, Some(group_id.to_owned()))
+            .filter_annotations_api(filters, group_id.to_owned())
             .await?;
         if search || fuzzy {
             // Run a search window.
@@ -215,24 +209,16 @@ impl Gooseberry {
         Ok(())
     }
 
-    /// Filter annotations based on command-line flags
-    pub async fn filter_annotations(
+    /// Filter annotations using hypothesis API based on command-line flags
+    pub async fn filter_annotations_api(
         &self,
         filters: Filters,
-        group: Option<String>,
+        group: String,
     ) -> color_eyre::Result<Vec<Annotation>> {
-        let group = match group {
-            Some(group) => group,
-            None => self
-                .config
-                .hypothesis_group
-                .clone()
-                .ok_or_else(|| eyre!("This should have been set by Config"))?,
-        };
         let mut query: SearchQuery = filters.clone().into();
         query.user = self.api.user.0.to_owned();
         query.group = group.to_string();
-        let mut annotations = if filters.or && !filters.tags.is_empty() {
+        let mut annotations = if !filters.and && !filters.tags.is_empty() {
             let mut annotations = Vec::new();
             for tag in &filters.tags {
                 let mut tag_query = query.clone();
@@ -270,17 +256,140 @@ impl Gooseberry {
         Ok(annotations)
     }
 
+    pub fn filter_annotation(&self, annotation: &Annotation, filters: &Filters) -> (String, bool) {
+        if filters.page && annotation.target.iter().any(|t| !t.selector.is_empty()) {
+            return ("Not a page note".into(), false);
+        }
+        if filters.annotation && annotation.target.iter().all(|t| t.selector.is_empty()) {
+            return ("Not an annotation".into(), false);
+        }
+        if let Some(from) = filters.from {
+            if filters.include_updated {
+                if annotation.updated < from {
+                    return (
+                        format!("Updated {:?} < {:?}", annotation.updated, from),
+                        false,
+                    );
+                }
+            } else if annotation.created < from {
+                return (
+                    format!("Created {:?} < {:?}", annotation.created, from),
+                    false,
+                );
+            }
+        }
+        if let Some(before) = filters.before {
+            if filters.include_updated {
+                if annotation.updated > before {
+                    return (
+                        format!("Updated {:?} > {:?}", annotation.updated, before),
+                        false,
+                    );
+                }
+            } else if annotation.created > before {
+                return (
+                    format!("Created {:?} > {:?}", annotation.created, before),
+                    false,
+                );
+            }
+        }
+        if !filters.uri.is_empty() && !annotation.uri.contains(&filters.uri) {
+            return (
+                format!("{:?} not in URI {:?}", filters.uri, annotation.uri),
+                false,
+            );
+        }
+
+        if !(filters.any.is_empty()
+            || utils::get_quotes(annotation)
+                .join(" ")
+                .contains(&filters.any)
+            || annotation.tags.iter().any(|t| t.contains(&filters.any))
+            || annotation.text.contains(&filters.any)
+            || annotation.uri.contains(&filters.any))
+        {
+            return (format!("{:?} not in annotation", filters.any), false);
+        }
+
+        if !filters.tags.is_empty() {
+            if filters.and {
+                if !annotation.tags.iter().all(|t| filters.tags.contains(t)) {
+                    return (
+                        format!("{:?} not in all tags {:?}", filters.tags, annotation.tags),
+                        false,
+                    );
+                }
+            } else if !annotation.tags.iter().any(|t| filters.tags.contains(t)) {
+                return (
+                    format!("{:?} not in any tags {:?}", filters.tags, annotation.tags),
+                    false,
+                );
+            }
+        }
+
+        if !filters.exclude_tags.is_empty()
+            && annotation
+                .tags
+                .iter()
+                .any(|t| filters.exclude_tags.contains(t))
+        {
+            return (
+                format!(
+                    "{:?} in exclude tags {:?}",
+                    annotation.tags, filters.exclude_tags
+                ),
+                false,
+            );
+        }
+
+        if !filters.quote.is_empty()
+            && !utils::get_quotes(annotation)
+                .join(" ")
+                .contains(&filters.quote)
+        {
+            return (
+                format!(
+                    "{:?} not in quote {:?}",
+                    filters.quote,
+                    utils::get_quotes(annotation).join(" ")
+                ),
+                false,
+            );
+        }
+        if !filters.text.is_empty() && !annotation.text.contains(&filters.text) {
+            return (
+                format!("{:?} not in text {:?}", filters.text, annotation.text),
+                false,
+            );
+        }
+        ("Passed".into(), true)
+    }
+
+    /// Filter annotations based on command-line flags
+    pub fn filter_annotations(&self, filters: Filters) -> color_eyre::Result<Vec<Annotation>> {
+        let mut annotations = Vec::new();
+        for annotation in self.iter_annotations()? {
+            let annotation = annotation?;
+            let (_, keep) = self.filter_annotation(&annotation, &filters);
+            if filters.not {
+                if !keep {
+                    annotations.push(annotation);
+                }
+            } else if keep {
+                annotations.push(annotation);
+            }
+        }
+        annotations.sort_by(|a, b| a.created.cmp(&b.created));
+        Ok(annotations)
+    }
+
     /// Fetch annotations for knowledge base
     /// Ignores annotations with tags in `ignore_tags` configuration option.
-    pub async fn filter_annotations_make(
-        &self,
-        filters: Filters,
-    ) -> color_eyre::Result<Vec<Annotation>> {
+    pub fn filter_annotations_make(&self, filters: Filters) -> color_eyre::Result<Vec<Annotation>> {
         let pb = utils::get_spinner("Fetching annotations...");
         // Get all annotations
         let annotations: Vec<_> = self
-            .filter_annotations(filters, None)
-            .await?
+            .filter_annotations(filters)?
             .into_iter()
             .filter(|a| {
                 !a.tags.iter().any(|t| {
@@ -425,16 +534,14 @@ impl Gooseberry {
     }
 
     /// View optionally filtered annotations in the terminal
-    pub async fn view(&mut self, filters: Filters, id: Option<String>) -> color_eyre::Result<()> {
+    pub fn view(&mut self, filters: Filters, id: Option<String>) -> color_eyre::Result<()> {
         if self.config.annotation_template.is_none() {
             self.config.set_annotation_template()?;
         }
         let hbs = self.get_handlebars()?;
         if let Some(id) = id {
             let annotation = self
-                .api
-                .fetch_annotation(&id)
-                .await
+                .get_annotation(&id)
                 .suggestion("Are you sure this is a valid and existing annotation ID?")?;
             let markdown = hbs.render(
                 "annotation",
@@ -448,8 +555,7 @@ impl Gooseberry {
             return Ok(());
         }
         let inputs: Vec<_> = self
-            .filter_annotations(filters, None)
-            .await?
+            .filter_annotations(filters)?
             .into_iter()
             .map(|annotation| {
                 hbs.render(

--- a/src/gooseberry/search.rs
+++ b/src/gooseberry/search.rs
@@ -188,7 +188,7 @@ impl Gooseberry {
                         .with_prompt("Also make index file?")
                         .default(true)
                         .interact()?;
-                    self.make(annotations, clear, true, true, index).await?;
+                    self.make(annotations, clear, true, true, index)?;
                 }
                 Key::ShiftUp => {
                     self.uri(annotations, Vec::new())?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -199,7 +199,7 @@ async fn tag_filter() -> color_eyre::Result<()> {
     let test_data = TestData::populate().await;
     assert!(test_data.is_ok());
     let test_data = test_data?;
-    let duration = time::Duration::from_millis(500);
+    let duration = time::Duration::from_millis(1000);
 
     // check sync
     thread::sleep(duration);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -391,13 +391,13 @@ async fn tag_filter() -> color_eyre::Result<()> {
         .tags
         .contains(&"test_tag7".to_owned()));
 
-    // OR
+    // AND
     thread::sleep(duration);
     let mut cmd = Command::cargo_bin("gooseberry")?;
     cmd.env("GOOSEBERRY_CONFIG", &test_data.config_file)
         .arg("tag")
-        .arg("--tags=test_tag1,test_tag2")
-        .arg("--or")
+        .arg("--tags=test_tag,test_tag1,test_tag5,test_tag7")
+        .arg("--and")
         .arg("test_tag8")
         .assert()
         .success();
@@ -409,8 +409,8 @@ async fn tag_filter() -> color_eyre::Result<()> {
         .await?
         .tags
         .contains(&"test_tag8".to_owned()));
-    // in a2
-    assert!(test_data
+    // NOT in a2
+    assert!(!test_data
         .hypothesis_client
         .fetch_annotation(&test_data.annotations[1].id)
         .await?


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Stores annotations in local sled database using CBOR format so that search, view, uri, make and index commands can be run offline without queries to the Hypothesis API.

Closes #76 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/out-of-cheese-error/gooseberry/blob/master/docs/CONTRIBUTING.md
- you have linted the code using clippy:
  https://github.com/rust-lang/rust-clippy
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all` (see CONTRIBUTING.md for information on setting up tests)
- you have updated the changelog (if needed):
  https://github.com/out-of-cheese-error/gooseberry/blob/master/CHANGELOG.md
-->
