### PR TITLE
Adding support for multiple groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -355,6 +355,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -420,7 +426,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
- "indexmap 1.6.2",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -491,7 +497,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e87cbed5354f17bd8ca8821a097fb62599787fe8f611743fad7ee156a0a600"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "serde",
  "winapi",
@@ -532,13 +538,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "confy"
-version = "0.5.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37668cb35145dcfaa1931a5f37fde375eeae8068b4c0d2f289da28a270b2d2c"
+checksum = "2913470204e9e8498a0f31f17f90a0de801ae92c8c5ac18c49af4819e6786697"
 dependencies = [
  "directories",
  "serde",
- "thiserror",
  "toml 0.5.8",
 ]
 
@@ -586,7 +591,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -595,7 +600,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb9105919ca8e40d437fc9cbb8f1975d916f1bd28afe795a48aae32a2cc8920"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -609,7 +614,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -619,7 +624,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -631,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -641,7 +646,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc6598521bb5a83d491e8c1fe51db7296019d2ca3cb93cc6c2a20369a4d78a2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -651,7 +656,7 @@ version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -806,10 +811,11 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -819,7 +825,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a28ccebc1239c5c57f0c55986e2ac03f49af0d0ca3dff29bfcad39d60a8be56"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -829,7 +835,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -885,7 +891,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1121,7 +1127,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -1242,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1408,12 +1414,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1445,7 +1451,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1607,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -1619,7 +1625,7 @@ checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset",
  "pin-utils",
@@ -1715,7 +1721,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.13",
@@ -2434,7 +2440,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
@@ -2879,7 +2885,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -2904,7 +2910,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3218,7 +3224,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap_complete = "4.4.5"
 sled = "0.34.7"
 
 # Configuration management
-confy = "0.5.1"
+confy = "0.4.0"
 directories-next = "1.0.1"
 
 # Error handling

--- a/README.md
+++ b/README.md
@@ -137,50 +137,55 @@ you got it from, if ever you feel like you're missing context.
 You can filter the annotations you want to modify or export using the following options in most gooseberry commands:
 
 ```
-FLAGS:
-    -i, --include-updated
-            Include annotations updated in given time range (instead of just created)
+    --from <FROM>
+        Only annotations created after this date and time
+        
+        Can be colloquial, e.g. "last Friday 8pm"
 
-    -n, --not
-            Annotations NOT matching the given filter criteria
+    --before <BEFORE>
+        Only annotations created before this date and time
+        
+        Can be colloquial, e.g. "last Friday 8pm"
 
-    -o, --or
-            (Use with --tags) Annotations matching ANY of the given tags
+    --uri <URI>
+        Only annotations with this pattern in their URL
+        
+        Doesn't have to be the full URL, e.g. "wikipedia"
 
-    -p, --page
-            Only page notes
+    --any <ANY>
+        Only annotations with this pattern in their `quote`, `tags`, `text`, or `uri`
 
-    -a, --annotation
-            Only annotations (i.e exclude page notes)
+    --tags <TAGS>
+        Only annotations with ANY of these tags (use --and to match ALL)
 
+    --groups <GROUPS>
+        Only annotations from these groups
 
-OPTIONS:
-        --from <from>
-            Only annotations created after this date and time
+    --exclude-tags <EXCLUDE_TAGS>
+        Only annotations without ANY of these tags
 
-            Can be colloquial, e.g. "last Friday 8pm"
-        --before <before>
-            Only annotations created before this date and time
+    --quote <QUOTE>
+        Only annotations that contain this text inside the text that was annotated
 
-            Can be colloquial, e.g. "last Friday 8pm"
-        --uri <uri>
-            Only annotations with this pattern in their URL
+    --text <TEXT>
+        Only annotations that contain this text in their textual body
 
-            Doesn't have to be the full URL, e.g. "wikipedia" [default: ]
-        --any <any>
-            Only annotations with this pattern in their `quote`, `tags`, `text`, or `uri` [default: ]
+-i, --include-updated
+        Include annotations updated in given time range (instead of just created)
+-n, --not
+        Annotations NOT matching the given filter criteria
 
-        --tags <tags>...
-            Only annotations with ALL of these tags (use --or to match ANY)
+    --and
+        (Use with --tags) Annotations matching ALL of the given tags
 
-        --exclude-tags <exclude-tags>...
-            Only annotations without ANY of these tags
+-p, --page
+        Only page notes
 
-        --quote <quote>
-            Only annotations that contain this text inside the text that was annotated [default: ]
+-a, --annotation
+        Only annotations (i.e exclude page notes)
 
-        --text <text>
-            Only annotations that contain this text in their textual body [default: ]
+-f, --fuzzy
+        Toggle fuzzy search
 ```
 
 ## Customization
@@ -199,7 +204,7 @@ variable `$GOOSEBERRY_CONFIG` to point to the file.
 Authorize Hypothesis either by setting the `$HYPOTHESIS_NAME` and `$HYPOTHESIS_KEY` environment variables to your username and developer API token or
 by running `gooseberry config authorize`.
 
-Gooseberry takes annotations from a given Hypothesis group which you can create/set with `gooseberry config group`.
+Gooseberry takes annotations from given Hypothesis group(s) which you can create/set with `gooseberry config group`.
 
 ### Knowledge base
 
@@ -241,6 +246,7 @@ The following keys can be used inside the template
 * `{{ text }}` - The text content of the annotation body
 * `tags` - A list of tags associated with the annotation.
 * `{{ group }}` - ID of Hypothesis group,
+* `{{ group_name }}` - Name of Hypothesis group,
 * `references` - List of annotation IDs for any annotations this annotation references (e.g. is a reply to)
 * `{{ display_name }}` - Display name of annotation creator. This may not be set.
 
@@ -348,12 +354,14 @@ The available options are:
 * BaseURI - Groups annotations by their base URI
 * Title - Group annotations by the title of their webpage/article/document
 * ID - Groups annotations by annotation ID.
+* Group - Groups annotations by group ID.
+* GroupName - Groups annotations by group name.
 
 Multiple hierarchies combined make folders and sub-folders, with the last entry defining pages.
 
 e.g.
 
-`hierarchy = ["BaseURI", "Tag"]` would make a separate folder for each base_uri. Within each folder would be a page for each tag consisting of
+`hierarchy = ["Group", "Tag"]` would make a separate folder for each group. Within each folder would be a page for each tag consisting of
 annotations marked with that tag.
 
 `hierarchy = ["Tag"]` gives the structure in the `mdbook` figure above, i.e. no folders, a page for each tag.
@@ -371,6 +379,8 @@ The available options are:
 * BaseURI
 * Title
 * ID
+* Group
+* GroupName
 * Created
 * Updated
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -418,6 +418,7 @@ file_extension = '{}'
             OrderBy::BaseURI,
             OrderBy::Title,
             OrderBy::ID,
+            OrderBy::GroupID,
             OrderBy::Group,
         ];
         let order = Self::get_order_bys(selections)?;
@@ -460,6 +461,7 @@ file_extension = '{}'
             OrderBy::Title,
             OrderBy::Created,
             OrderBy::Updated,
+            OrderBy::GroupID,
             OrderBy::Group,
         ];
         let order = Self::get_order_bys(selections)?;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -22,7 +22,7 @@ pub static DEFAULT_NESTED_TAG: &str = "/";
 pub static DEFAULT_ANNOTATION_TEMPLATE: &str = r#"
 
 ### {{id}}
-Group: {{group_id}} ({{group_name}})
+Group: {{group}} ({{group_name}})
 Created: {{date_format "%c" created}}
 Tags: {{#each tags}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}
 
@@ -53,8 +53,8 @@ pub enum OrderBy {
     Empty,
     Created,
     Updated,
-    GroupID,
     Group,
+    GroupName,
 }
 
 impl fmt::Display for OrderBy {
@@ -68,8 +68,8 @@ impl fmt::Display for OrderBy {
             OrderBy::Empty => write!(f, "empty"),
             OrderBy::Created => write!(f, "created"),
             OrderBy::Updated => write!(f, "updated"),
-            OrderBy::GroupID => write!(f, "group_id"),
             OrderBy::Group => write!(f, "group"),
+            OrderBy::GroupName => write!(f, "group_name"),
         }
     }
 }
@@ -418,8 +418,8 @@ file_extension = '{}'
             OrderBy::BaseURI,
             OrderBy::Title,
             OrderBy::ID,
-            OrderBy::GroupID,
             OrderBy::Group,
+            OrderBy::GroupName,
         ];
         let order = Self::get_order_bys(selections)?;
         if order.is_empty() {
@@ -461,8 +461,8 @@ file_extension = '{}'
             OrderBy::Title,
             OrderBy::Created,
             OrderBy::Updated,
-            OrderBy::GroupID,
             OrderBy::Group,
+            OrderBy::GroupName,
         ];
         let order = Self::get_order_bys(selections)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use hypothesis::errors::HypothesisError;
 use thiserror::Error;
 
 /// "It claimed to have 15 functions, although it appeared that at least ten were apologizing for
@@ -10,9 +11,9 @@ pub enum Apologize {
     /// Thrown when trying annotation ID doesn't match any recorded annotations
     #[error("Couldn't find an annotation with ID {id:?}")]
     AnnotationNotFound { id: String },
-    /// Thrown when trying to access an unrecorded tag
-    #[error("Couldn't find group {id:?}. The Group ID can be found in the URL of the group: https://hypothes.is/groups/<group_id>/<group_name>")]
-    GroupNotFound { id: String },
+    /// Thrown when trying to access an unrecorded group
+    #[error("Couldn't access group {id:?}: {error:?}. The Group ID can be found in the URL of the group: https://hypothes.is/groups/<group_id>/<group_name>")]
+    GroupNotFound { id: String, error: HypothesisError },
     /// Thrown when explicit Y not received from user for destructive things
     #[error("I'm a coward. Doing nothing.")]
     DoingNothing,

--- a/src/gooseberry/cli.rs
+++ b/src/gooseberry/cli.rs
@@ -155,6 +155,9 @@ pub struct Filters {
     /// Only annotations with ANY of these tags (use --and to match ALL)
     #[clap(long, value_delimiter = ',')]
     pub tags: Vec<String>,
+    /// Only annotations from these groups
+    #[clap(long, value_delimiter = ',')]
+    pub groups: Vec<String>,
     /// Only annotations without ANY of these tags
     #[clap(long, value_delimiter = ',')]
     pub exclude_tags: Vec<String>,
@@ -202,6 +205,7 @@ impl From<Filters> for SearchQuery {
             },
             quote: filters.quote,
             text: filters.text,
+            group: filters.groups,
             ..SearchQuery::default()
         }
     }
@@ -232,8 +236,11 @@ pub enum ConfigCommand {
     Where,
     /// Change Hypothesis credentials
     Authorize,
-    /// Change the group used for Hypothesis annotations
-    Group { group_id: Option<String> },
+    /// Change the groups used for Hypothesis annotations
+    Group {
+        #[clap(value_delimiter = ',', required = false)]
+        group_ids: Vec<String>,
+    },
     /// Change options related to the knowledge base
     Kb {
         #[clap(subcommand)]
@@ -285,9 +292,9 @@ impl ConfigCommand {
                 let mut config = GooseberryConfig::load(config_file).await?;
                 config.request_credentials().await?;
             }
-            Self::Group { group_id } => {
+            Self::Group { group_ids } => {
                 let mut config = GooseberryConfig::load(config_file).await?;
-                config.set_group(group_id.clone()).await?;
+                config.set_groups(group_ids.clone()).await?;
             }
             Self::Kb { cmd } => {
                 let mut config = GooseberryConfig::load(config_file).await?;

--- a/src/gooseberry/knowledge_base.rs
+++ b/src/gooseberry/knowledge_base.rs
@@ -35,6 +35,8 @@ pub struct AnnotationTemplate {
     pub incontext: String,
     pub highlight: Vec<String>,
     pub display_name: Option<String>,
+    pub group_name: String,
+    pub group_id: String,
 }
 
 pub fn replace_spaces(astring: &str) -> String {
@@ -42,7 +44,10 @@ pub fn replace_spaces(astring: &str) -> String {
 }
 
 impl AnnotationTemplate {
-    pub(crate) fn from_annotation(annotation: Annotation) -> Self {
+    pub(crate) fn from_annotation(
+        annotation: Annotation,
+        hypothesis_groups: &HashMap<String, String>,
+    ) -> Self {
         let base_uri = if let Ok(uri) = Url::parse(&annotation.uri) {
             uri[..url::Position::BeforePath].to_string()
         } else {
@@ -68,6 +73,11 @@ impl AnnotationTemplate {
                 title = document.title[0].to_owned();
             }
         }
+        let group_name = hypothesis_groups
+            .get(&annotation.group)
+            .unwrap_or(&annotation.group)
+            .to_owned();
+        let group_id = annotation.group.to_owned();
         AnnotationTemplate {
             annotation,
             base_uri,
@@ -75,6 +85,8 @@ impl AnnotationTemplate {
             incontext,
             highlight,
             display_name,
+            group_name,
+            group_id,
         }
     }
 }
@@ -219,6 +231,22 @@ fn group_annotations_by_order(
                     .push(annotation);
             }
         }
+        OrderBy::GroupID => {
+            for annotation in annotations {
+                order_to_annotations
+                    .entry(annotation.group_id.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(annotation);
+            }
+        }
+        OrderBy::Group => {
+            for annotation in annotations {
+                order_to_annotations
+                    .entry(annotation.group_name.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(annotation);
+            }
+        }
         OrderBy::Empty => panic!("Shouldn't happen"),
         _ => panic!("{} shouldn't occur in hierarchy", order),
     }
@@ -242,6 +270,8 @@ fn sort_annotations(sort: &[OrderBy], annotations: &mut [AnnotationTemplate]) {
                     .cmp(&format!("{}", b.annotation.created.format("%+"))),
                 OrderBy::Updated => format!("{}", a.annotation.updated.format("%+"))
                     .cmp(&format!("{}", b.annotation.updated.format("%+"))),
+                OrderBy::GroupID => a.group_id.cmp(&b.group_id),
+                OrderBy::Group => a.group_name.cmp(&b.group_name),
                 OrderBy::Empty => panic!("Shouldn't happen"),
             })
         })
@@ -309,7 +339,7 @@ impl Gooseberry {
     ) -> color_eyre::Result<()> {
         let mut annotations: Vec<_> = annotations
             .into_iter()
-            .map(AnnotationTemplate::from_annotation)
+            .map(|a| AnnotationTemplate::from_annotation(a, &self.config.hypothesis_groups))
             .collect();
         let extension = self
             .config

--- a/src/gooseberry/knowledge_base.rs
+++ b/src/gooseberry/knowledge_base.rs
@@ -36,7 +36,6 @@ pub struct AnnotationTemplate {
     pub highlight: Vec<String>,
     pub display_name: Option<String>,
     pub group_name: String,
-    pub group_id: String,
 }
 
 pub fn replace_spaces(astring: &str) -> String {
@@ -77,7 +76,6 @@ impl AnnotationTemplate {
             .get(&annotation.group)
             .unwrap_or(&annotation.group)
             .to_owned();
-        let group_id = annotation.group.to_owned();
         AnnotationTemplate {
             annotation,
             base_uri,
@@ -86,7 +84,6 @@ impl AnnotationTemplate {
             highlight,
             display_name,
             group_name,
-            group_id,
         }
     }
 }
@@ -231,15 +228,15 @@ fn group_annotations_by_order(
                     .push(annotation);
             }
         }
-        OrderBy::GroupID => {
+        OrderBy::Group => {
             for annotation in annotations {
                 order_to_annotations
-                    .entry(annotation.group_id.to_string())
+                    .entry(annotation.annotation.group.to_string())
                     .or_insert_with(Vec::new)
                     .push(annotation);
             }
         }
-        OrderBy::Group => {
+        OrderBy::GroupName => {
             for annotation in annotations {
                 order_to_annotations
                     .entry(annotation.group_name.to_string())
@@ -270,8 +267,8 @@ fn sort_annotations(sort: &[OrderBy], annotations: &mut [AnnotationTemplate]) {
                     .cmp(&format!("{}", b.annotation.created.format("%+"))),
                 OrderBy::Updated => format!("{}", a.annotation.updated.format("%+"))
                     .cmp(&format!("{}", b.annotation.updated.format("%+"))),
-                OrderBy::GroupID => a.group_id.cmp(&b.group_id),
-                OrderBy::Group => a.group_name.cmp(&b.group_name),
+                OrderBy::Group => a.annotation.group.cmp(&b.annotation.group),
+                OrderBy::GroupName => a.group_name.cmp(&b.group_name),
                 OrderBy::Empty => panic!("Shouldn't happen"),
             })
         })

--- a/src/gooseberry/search.rs
+++ b/src/gooseberry/search.rs
@@ -139,7 +139,10 @@ impl Gooseberry {
                 highlight,
                 markdown: hbs.render(
                     "annotation",
-                    &AnnotationTemplate::from_annotation(annotation.clone()),
+                    &AnnotationTemplate::from_annotation(
+                        annotation.clone(),
+                        &self.config.hypothesis_groups,
+                    ),
                 )?,
                 id: annotation.id.to_owned(),
             }));
@@ -320,7 +323,10 @@ impl Gooseberry {
                 highlight,
                 markdown: hbs.render(
                     "annotation",
-                    &AnnotationTemplate::from_annotation(annotation.clone()),
+                    &AnnotationTemplate::from_annotation(
+                        annotation.clone(),
+                        &self.config.hypothesis_groups,
+                    ),
                 )?,
                 id: annotation.id.to_owned(),
             }));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,7 +28,7 @@ fn make_config_file(
 db_dir = '{}'
 hypothesis_username = '{}'
 hypothesis_key = '{}'
-hypothesis_group = '{}'
+hypothesis_groups = {{'{}' = "test_group"}}
 kb_dir = '{}'
 hierarchy = ['Tag']
 sort = ['Created']


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Fixes #9 

- [X] allow multiple groups in config
- [X] add group_id (GroupID) and group name (Group) to hirearchy and sort options
- [X] add group_id(s) as a search filter
- [X] add group_id and group_name to annotation template
- [ ] add tests
- [ ] update readme 
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/out-of-cheese-error/gooseberry/blob/master/docs/CONTRIBUTING.md
- you have linted the code using clippy:
  https://github.com/rust-lang/rust-clippy
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all` (see CONTRIBUTING.md for information on setting up tests)
- you have updated the changelog (if needed):
  https://github.com/out-of-cheese-error/gooseberry/blob/master/CHANGELOG.md
-->
