### PR TITLE
Pull annotations from other users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "hypothesis"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9714d3b087290cabd4e66d9943f62b7da4cb74bf413a69b53de31b779429a647"
+checksum = "d35ec5ab51dd4a819db01754b95303370119e9223b131c9a673462da0def1ff0"
 dependencies = [
  "chrono",
  "derive_builder 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ include = ["src/**/*", "README.md"]
 
 [dependencies]
 # Hypothesis
-hypothesis = { version = "0.11.1", default-features = false }
+hypothesis = { version = "0.11.5", default-features = false }
+# hypothesis = { path = "../rust-hypothesis" }
 tokio = { version = "1.20.1", features = ["macros"] }
 
 # To extract the base URI

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -109,6 +109,8 @@ pub struct GooseberryConfig {
     /// Define nested tag pattern
     pub(crate) nested_tag: Option<String>,
     /// Hypothesis groups with knowledge base annotations
+    /// Other Hypothesis usernames to pull public annotations from
+    pub(crate) hypothesis_users: Option<Vec<String>>,
     #[serde(default)]
     pub(crate) hypothesis_groups: HashMap<String, String>,
 }
@@ -138,6 +140,7 @@ impl Default for GooseberryConfig {
             sort: None,
             ignore_tags: None,
             nested_tag: None,
+            hypothesis_users: None,
         };
         config.make_dirs().expect("Couldn't make directories");
         config

--- a/src/gooseberry/knowledge_base.rs
+++ b/src/gooseberry/knowledge_base.rs
@@ -34,6 +34,7 @@ pub struct AnnotationTemplate {
     pub title: String,
     pub incontext: String,
     pub highlight: Vec<String>,
+    pub username: String,
     pub display_name: Option<String>,
     pub group_name: String,
 }
@@ -66,6 +67,7 @@ impl AnnotationTemplate {
         } else {
             None
         };
+        let username = annotation.user.to_username();
         let mut title = String::from("Untitled document");
         if let Some(document) = &annotation.document {
             if !document.title.is_empty() {
@@ -82,6 +84,7 @@ impl AnnotationTemplate {
             title,
             incontext,
             highlight,
+            username,
             display_name,
             group_name,
         }

--- a/src/gooseberry/mod.rs
+++ b/src/gooseberry/mod.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
 use std::path::Path;
+use std::str::FromStr;
 use std::{fs, vec};
 
+use chrono::Utc;
 use color_eyre::Help;
 use dialoguer::Confirm;
 use eyre::eyre;
 use hypothesis::annotations::{Annotation, Order, SearchQuery};
-use hypothesis::Hypothesis;
+use hypothesis::{Hypothesis, UserAccountID};
 
 use crate::configuration::GooseberryConfig;
 use crate::errors::Apologize;
@@ -157,16 +159,26 @@ impl Gooseberry {
             spinner.finish_with_message("No groups to sync!");
             return Ok(());
         }
-        let mut query = SearchQuery::builder()
-            .limit(200)
-            .order(Order::Asc)
-            .search_after(self.get_sync_time()?)
-            .user(&self.api.user.0)
-            .group(groups)
-            .build()?;
-        let (added, updated) =
-            self.sync_annotations(self.api.search_annotations_return_all(&mut query).await?)?;
-        self.set_sync_time(&query.search_after)?;
+        let mut user_ids = vec![self.api.user.to_user_id()];
+        if let Some(users) = &self.config.hypothesis_users {
+            for user in users {
+                user_ids.push(UserAccountID::from_str(user)?.to_user_id());
+            }
+        }
+        let mut annotations = Vec::new();
+        let sync_time = self.get_sync_time()?;
+        for user_id in user_ids {
+            let mut query = SearchQuery::builder()
+                .limit(200)
+                .order(Order::Asc)
+                .search_after(&sync_time)
+                .user(&user_id)
+                .group(groups.clone())
+                .build()?;
+            annotations.extend(self.api.search_annotations_return_all(&mut query).await?);
+        }
+        let (added, updated) = self.sync_annotations(annotations)?;
+        self.set_sync_time(&Utc::now().to_rfc3339())?;
         spinner.finish_with_message("Done!");
         if added > 0 {
             if added == 1 {
@@ -197,7 +209,7 @@ impl Gooseberry {
         fuzzy: bool,
     ) -> color_eyre::Result<()> {
         let mut annotations = self
-            .filter_annotations_api(filters, vec![group_id.clone()])
+            .filter_annotations_api(filters, vec![group_id.clone()], self.api.user.to_user_id())
             .await?;
         if search || fuzzy {
             // Run a search window.
@@ -228,9 +240,10 @@ impl Gooseberry {
         &self,
         filters: Filters,
         groups: Vec<String>,
+        user_id: String,
     ) -> color_eyre::Result<Vec<Annotation>> {
         let mut query: SearchQuery = filters.clone().into();
-        query.user = self.api.user.0.to_owned();
+        query.user = user_id.to_owned();
         query.group = groups.clone();
         let mut annotations = if !filters.and && !filters.tags.is_empty() {
             let mut annotations = Vec::new();
@@ -258,7 +271,7 @@ impl Gooseberry {
         }
         if filters.not {
             let mut query: SearchQuery = Filters::default().into();
-            query.user = self.api.user.0.to_owned();
+            query.user = user_id;
             query.group = groups;
             let mut all_annotations: Vec<_> =
                 self.api.search_annotations_return_all(&mut query).await?;


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Closes #108 

adds `hypothesis_users` as a config key to pull annotations from users other than the authorized user

TODO:
- [ ] check how this interfaces with tagging and deleting
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/out-of-cheese-error/gooseberry/blob/master/docs/CONTRIBUTING.md
- you have linted the code using clippy:
  https://github.com/rust-lang/rust-clippy
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all` (see CONTRIBUTING.md for information on setting up tests)
- you have updated the changelog (if needed):
  https://github.com/out-of-cheese-error/gooseberry/blob/master/CHANGELOG.md
-->
